### PR TITLE
Add rvhaplo fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .snakemake/
 resources/downloaded_ref_files/
 results/
+telsvirus_biosamples/
+rvhaplo_test/

--- a/config/README.md
+++ b/config/README.md
@@ -15,6 +15,7 @@ To configure this workflow, modify `config/config.yaml` according to your needs,
 | `similarity_threshold` | 0.9 |
 | `crop_len` | 37 |
 | `sftclp_cutoff` | 0.5 |
+| `ref_length_limit` | 12000 |
 
 > *NOTE: All files can exist outside of the TELSVirus directory as long as paths are correct. Alternatively files can be symbolically linked or copied to the desired location.*
 
@@ -72,3 +73,7 @@ This value determines how similar two sequences have to be to eachother to be co
 ## Soft Clip Cutoff
 
 This value is the percentage threshold of a read that must be soft-clipped in an alignment for that particular alignment to be removed from further processing.
+
+## Reference Length Limit
+
+This value sets the cutoff length for references to be processed through RVHaplo. The ref_length_limit can be raised to process longer references, however, compute time increases exponentially with reference length and total read count. Best practice would be to leave the default in place and process additional samples independently using the alignment outputs already produced by the pipeline.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,12 +1,13 @@
-email: ""
-run_id: "test"
+email: "jonathan.bravo@ufl.edu"
+run_id: "telsvirus_biosamples"
 output: "results/"
 host_organism: "Sus Scrofa"
 host_genome: ""
 viral_genomes: "resources/test/allvirusgenomes_poly-a_removed_hand_edit.fasta"
 strain_db: "resources/test/strain_db.tsv"
 barcodes: "resources/test/RapidBarcode.fasta"
-reads: "resources/test/reads"
+reads: "telsvirus_biosamples/reads"
 silimarity_threshold: 0.9
 crop_len: 37
 sftclp_cutoff: 0.5
+ref_length_limit: 12000

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,12 +1,12 @@
-email: "jonathan.bravo@ufl.edu"
-run_id: "telsvirus_biosamples"
+email: ""
+run_id: "test"
 output: "results/"
 host_organism: "Sus Scrofa"
 host_genome: ""
 viral_genomes: "resources/test/allvirusgenomes_poly-a_removed_hand_edit.fasta"
 strain_db: "resources/test/strain_db.tsv"
 barcodes: "resources/test/RapidBarcode.fasta"
-reads: "telsvirus_biosamples/reads"
+reads: "resources/test/reads"
 silimarity_threshold: 0.9
 crop_len: 37
 sftclp_cutoff: 0.5

--- a/resources/rvhaplo-threadpool.patch
+++ b/resources/rvhaplo-threadpool.patch
@@ -1,0 +1,62 @@
+diff --git a/src/mcp_read_graph.py b/src/mcp_read_graph.py
+--- a/src/mcp_read_graph.py
++++ b/src/mcp_read_graph.py
+@@ -5,7 +5,6 @@ import pysam
+ import numpy as np
+ import pickle
+ import multiprocessing as mp
+-mp.set_start_method("fork")
+
+ ### load data
+ file_in=sys.argv[1]
+@@ -56,7 +55,8 @@ print("Generate sequence matrix at candidate SNV sites")
+
+ query_list = [(r.get_aligned_pairs(matches_only=True),r.query_sequence,r.query_name,r.mapping_quality,ref_length,snv_sites) for r in bamfile.fetch()]
+-with concurrent.futures.ProcessPoolExecutor(thread) as executor:
++bamfile.close()
++with concurrent.futures.ThreadPoolExecutor(thread) as executor:
+     res = list(tqdm(executor.map(call_seq_mat, query_list), total=len(query_list)))
+
+@@ -85,7 +85,7 @@ def count_acgt(para):
+
+ print("Count base number at each candidate SNV site")
+ query_list = [seq_mat[:,i] for i in range(len(snv_sites))]
+-with concurrent.futures.ProcessPoolExecutor(thread) as executor:
++with concurrent.futures.ThreadPoolExecutor(thread) as executor:
+     res = list(tqdm(executor.map(count_acgt, query_list), total=len(query_list)))
+
+@@ -193,7 +193,7 @@ def verify_snv_site(site_id,to_be_verified_sites=to_be_verified_sites,seq_snv_fl
+ print("maximum conditional probability")
+ query_list = [i for i in to_be_verified_sites]
+
+-with concurrent.futures.ProcessPoolExecutor(thread) as executor:
++with concurrent.futures.ThreadPoolExecutor(thread) as executor:
+         snv_max_pro = list(tqdm(executor.map(verify_snv_site, query_list), total=len(query_list)))
+
+@@ -291,7 +291,7 @@ def writeedge(index_and_file):
+ if sub_graph == 1:
+     file = f'{file_prefix}_reads_graph.txt'
+     query_list = [[i,file] for i in range(len(index_r)-1)]
+-    with concurrent.futures.ProcessPoolExecutor(thread) as executor:
++    with concurrent.futures.ThreadPoolExecutor(thread) as executor:
+         results = list(tqdm(executor.map(writeedge, query_list), total=len(query_list)))
+ else:
+     for k in range(sub_graph):
+@@ -302,7 +302,7 @@ else:
+  #           temp = query_list[-1][0]+1
+  #           for i in range(temp,len(index_r)-1):
+  #               query_list.append([i,file])
+-        with concurrent.futures.ProcessPoolExecutor(thread) as executor:
++        with concurrent.futures.ThreadPoolExecutor(thread) as executor:
+             results = list(tqdm(executor.map(writeedge, query_list), total=len(query_list)))
+
+diff --git a/src/two_binomial.py b/src/two_binomial.py
+--- a/src/two_binomial.py
++++ b/src/two_binomial.py
+@@ -7,7 +7,6 @@ from scipy import stats
+ import numpy as np
+ import multiprocessing as mp
+-mp.set_start_method("fork")
+
+ #### input parameters
+ error = float(sys.argv[1])

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -20,6 +20,7 @@ READS = config["reads"]
 SIMILARITY = config["silimarity_threshold"]
 CROPLEN = config["crop_len"]
 CUTOFF = config["sftclp_cutoff"]
+REF_LENGTH_LIMIT = config["ref_length_limit"]
 OUTDIR = OUTPUT + RUNID
 LOGDIR = f"{OUTDIR}/snakemake_logs"
 BENCHDIR = f"{OUTDIR}/snakemake_benchmarks"
@@ -786,7 +787,8 @@ rule run_rvhaplo:
         sample="{sample}",
         vir_indir=f"{OUTDIR}/{{sample}}_viral_refs/",
         sam_indir=f"{OUTDIR}/{{sample}}_target_aligned/",
-        outdir=f"{OUTDIR}/{{sample}}_rvhaplo_out/"
+        outdir=f"{OUTDIR}/{{sample}}_rvhaplo_out/",
+        ref_length_limit=REF_LENGTH_LIMIT,
     conda:
         "envs/rvhaplo.yaml"
     threads: 32
@@ -800,7 +802,8 @@ rule run_rvhaplo:
         "{params.vir_indir} "
         "{params.sam_indir} "
         "{params.sample} "
-        "{threads}"
+        "{threads} "
+        "{params.ref_length_limit}"
 
 
 rule parse_rvhaplo_out:

--- a/workflow/envs/rvhaplo.yaml
+++ b/workflow/envs/rvhaplo.yaml
@@ -6,10 +6,11 @@ channels:
 dependencies:
   - python
   - samtools
-  - medaka
-  - scipy
+  - medaka<2
+  - scipy<1.12
   - pandas
   - tqdm
   - pysam
   - mcl
   - biopython
+  - setuptools=69.5.1

--- a/workflow/profiles/local/config.yaml
+++ b/workflow/profiles/local/config.yaml
@@ -1,6 +1,5 @@
-cores: 32
+cores: 8
 use-conda: True
 conda-frontend: conda
 latency-wait: 5
 rerun-incomplete: True
-jobs: 1

--- a/workflow/profiles/local/config.yaml
+++ b/workflow/profiles/local/config.yaml
@@ -1,5 +1,6 @@
-cores: 6
+cores: 32
 use-conda: True
 conda-frontend: conda
-latency-wait: 20
+latency-wait: 5
 rerun-incomplete: True
+jobs: 1

--- a/workflow/scripts/run_rvhaplo.sh
+++ b/workflow/scripts/run_rvhaplo.sh
@@ -1,52 +1,5 @@
 # #!/bin/bash
 
-# outdir=$1
-# vir_indir=$2
-# sam_indir=$3
-# barcode=$4
-# threads=$5
-# sub_graph=1
-
-# mkdir -p ${outdir};
-
-# for r in ${vir_indir}*;
-# do
-#     file="$(basename -- $r)";
-#     vir=${file%.fasta};
-#     sam_file=${sam_indir}${barcode}_aligned_${vir}.sam;
-
-#     # Skip if SAM file doesn't exist or is empty
-#     if [ ! -s "${sam_file}" ]; then
-#         echo "Skipping ${vir}: SAM file not found or empty"
-#         continue
-#     fi
-
-#     read_count=$(samtools view -c -F 260 ${sam_file} 2>/dev/null || echo "0");
-
-#     # Skip if no aligned reads
-#     if [ "${read_count}" -eq 0 ]; then
-#         echo "Skipping ${vir}: no aligned reads"
-#         continue
-#     fi
-
-#     if [ ${read_count} -gt 50000 ];
-#     then
-#         sub_graph=$(echo ${read_count}/25000 | bc)
-#     fi;
-
-#     # Run RVHaplo, but don't fail if it errors
-#     bash RVHaplo/rvhaplo.sh \
-#         -i ${sam_file} \
-#         -r ${r} \
-#         -t ${threads} \
-#         -sg ${sub_graph} \
-#         -l 0 \
-#         -o ${outdir}rvhaplo_${barcode}_${vir}/ || echo "RVHaplo failed for ${vir}, continuing..."
-# done
-
-# # Always exit successfully - parse_rvhaplo.py will handle empty results
-# exit 0
-
 outdir=$1
 vir_indir=$2
 sam_indir=$3

--- a/workflow/scripts/run_rvhaplo.sh
+++ b/workflow/scripts/run_rvhaplo.sh
@@ -1,11 +1,66 @@
-#!/bin/bash
+# #!/bin/bash
+
+# outdir=$1
+# vir_indir=$2
+# sam_indir=$3
+# barcode=$4
+# threads=$5
+# sub_graph=1
+
+# mkdir -p ${outdir};
+
+# for r in ${vir_indir}*;
+# do
+#     file="$(basename -- $r)";
+#     vir=${file%.fasta};
+#     sam_file=${sam_indir}${barcode}_aligned_${vir}.sam;
+
+#     # Skip if SAM file doesn't exist or is empty
+#     if [ ! -s "${sam_file}" ]; then
+#         echo "Skipping ${vir}: SAM file not found or empty"
+#         continue
+#     fi
+
+#     read_count=$(samtools view -c -F 260 ${sam_file} 2>/dev/null || echo "0");
+
+#     # Skip if no aligned reads
+#     if [ "${read_count}" -eq 0 ]; then
+#         echo "Skipping ${vir}: no aligned reads"
+#         continue
+#     fi
+
+#     if [ ${read_count} -gt 50000 ];
+#     then
+#         sub_graph=$(echo ${read_count}/25000 | bc)
+#     fi;
+
+#     # Run RVHaplo, but don't fail if it errors
+#     bash RVHaplo/rvhaplo.sh \
+#         -i ${sam_file} \
+#         -r ${r} \
+#         -t ${threads} \
+#         -sg ${sub_graph} \
+#         -l 0 \
+#         -o ${outdir}rvhaplo_${barcode}_${vir}/ || echo "RVHaplo failed for ${vir}, continuing..."
+# done
+
+# # Always exit successfully - parse_rvhaplo.py will handle empty results
+# exit 0
 
 outdir=$1
 vir_indir=$2
 sam_indir=$3
 barcode=$4
 threads=$5
+ref_length_limit=$6
 sub_graph=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+PATCH_FILE="${REPO_ROOT}/resources/rvhaplo-threadpool.patch"
+
+# Apply patch to RVHaplo submodule if not already applied
+(cd "${REPO_ROOT}/RVHaplo" && git apply --ignore-whitespace "${PATCH_FILE}" 2>/dev/null || true)
 
 mkdir -p ${outdir};
 
@@ -14,6 +69,8 @@ do
     file="$(basename -- $r)";
     vir=${file%.fasta};
     sam_file=${sam_indir}${barcode}_aligned_${vir}.sam;
+    ref_length=$(awk '/^>/ {if (seq) print length(seq); seq=""; next} {seq=seq $0} END {if (seq) print length(seq)}' $r)
+
 
     # Skip if SAM file doesn't exist or is empty
     if [ ! -s "${sam_file}" ]; then
@@ -34,14 +91,26 @@ do
         sub_graph=$(echo ${read_count}/25000 | bc)
     fi;
 
-    # Run RVHaplo, but don't fail if it errors
-    bash RVHaplo/rvhaplo.sh \
-        -i ${sam_file} \
-        -r ${r} \
+    # Resolve to absolute paths before cd-ing into RVHaplo source directory
+    abs_sam=$(readlink -f "${sam_file}")
+    abs_ref=$(readlink -f "${r}")
+    abs_out=$(readlink -f "${outdir}")
+
+    if [ "$ref_length" -ge "$ref_length_limit" ]; then
+        mkdir -p ${abs_out}/rvhaplo_${barcode}_${vir}/
+        touch ${abs_out}/rvhaplo_${barcode}_${vir}/viral-ref-too-long.flag
+        continue
+    fi
+
+    # Run RVHaplo from its source directory so ./src/ relative paths resolve correctly
+    # old `-l 0` meaning that all values are included in clustering, default `-l 50`
+    ## trying default, value but will have to tune parameter depending on data 
+    (cd RVHaplo && bash rvhaplo.sh \
+        -i "${abs_sam}" \
+        -r "${abs_ref}" \
         -t ${threads} \
         -sg ${sub_graph} \
-        -l 0 \
-        -o ${outdir}rvhaplo_${barcode}_${vir}/ || echo "RVHaplo failed for ${vir}, continuing..."
+        -o "${abs_out}/rvhaplo_${barcode}_${vir}/") || echo "RVHaplo failed for ${vir}, continuing..."
 done
 
 # Always exit successfully - parse_rvhaplo.py will handle empty results


### PR DESCRIPTION
Updated environment files so RVHaplo would not silently fail, and correctly produce haplotypes. Also added a reference length limit for haplotype generation, as longer references (more reads) lead to exponential growth in compute time.